### PR TITLE
Smooth tracer line

### DIFF
--- a/Track Buddy/MotionManager.swift
+++ b/Track Buddy/MotionManager.swift
@@ -99,11 +99,6 @@ class MotionManager: ObservableObject {
     
     private func interpolate(_ points: [Double]) -> [Double] {
         guard points.count > 0 else { return [] }
-        var indices: [Double] = []
-        for i in 0..<points.count {
-            indices.append(Double(i) * 1 / graphUpdateInterval)
-        }
-        
         let numberOfInterpolatedPoints = Int(Double(1) / Parameters.deviceMotionUpdateInterval * Double(points.count) * graphUpdateInterval)
         
         // Generate control array to smooth interpolation result

--- a/Track Buddy/New Group/AccelerometerGraph.swift
+++ b/Track Buddy/New Group/AccelerometerGraph.swift
@@ -29,7 +29,7 @@ struct AccelerometerGraph: View {
             
             ZStack(alignment: .center) {
                 Circle()
-                Path(motionManager.pointPath(atScale: pointScaleFactor))
+                Path(motionManager.pointPath(at: pointScaleFactor))
                     .stroke(Color.red, lineWidth: Metrics.tracerLineWidth)
                     .offset(x: geometry.size.width / 2, y: geometry.size.height / 2)
                 Circle()


### PR DESCRIPTION
![IMG_4187](https://user-images.githubusercontent.com/62192491/125115705-8d99fb00-e0a0-11eb-9ec7-c633d9fa5039.GIF)

Use smoothed quadratic interpolation to counteract very sharp and spiky appearance of tracer line that was a side effect of rate limiting points published to UI to 15 Hz (commit #2 ). 

Main thread is getting pretty crowded with this implementation, so next step is to see if handling interpolation calculations on a background thread would clear things up. 